### PR TITLE
fix: directory import error in node

### DIFF
--- a/src/signal.ts
+++ b/src/signal.ts
@@ -4,7 +4,7 @@
  * Make promises interruptable.
  */
 
-import { sleep } from '.';
+import { sleep } from './index.js';
 
 /**
  * Describe a signal


### PR DESCRIPTION
Trying to do `import {...} from 'ciorent'` results in this error in node:
```
Error: Directory import '/Users/tomer/Documents/work/code/limit-concur/node_modules/.pnpm/ciorent@0.11.1/node_modules/ciorent/' is not supported resolving ES modules imported from /Users/tomer/Documents/work/code/limit-concur/node_modules/.pnpm/ciorent@0.11.1/node_modules/ciorent/signal.js
```

I think node doesn't support importing directories like we're doing in `signal.ts`. I locally modified `node_modules` and this fixed it.